### PR TITLE
Fix: Prevent unrealistic typing speed and invalid inputs   #ieeesoc

### DIFF
--- a/typingtutor.c
+++ b/typingtutor.c
@@ -195,6 +195,22 @@ void processAttempts(FILE *file)
         clock_t endTime = clock();                                           // time stops
         double elapsedTime = (double)(endTime - startTime) / CLOCKS_PER_SEC; // elapsed time is calculated per sec
 
+        // Prevent unrealistically short elapsed time
+        if (elapsedTime < 1.0) {
+            printf("\n⚠️  Typing too fast or pasted input detected. Please type the paragraph manually.\n");
+            printf("This attempt will not be recorded.\n");
+            free(currentPara);
+            continue;
+        }
+
+        // Check if input is empty
+        if (strlen(input) == 0) {
+            printf("\n⚠️  No input detected. Please type something.\n");
+            free(currentPara);
+            continue;
+        }
+
+
         size_t len = strlen(input); // length of  the inputed para is stored in this
         if (len > 0 && input[len - 1] == '\n')
         {
@@ -212,7 +228,7 @@ void processAttempts(FILE *file)
         printf("--------------------------------------------------------\n");
 
         // Evaluate performance based on difficulty
-        if (currentAttempt.typingSpeed >= difficulty.hard) {
+        if (currentAttempt.typingSpeed >=    difficulty.hard) {
             printf("Performance Level: 🟢 Excellent (Hard)\n");
         } else if (currentAttempt.typingSpeed >= difficulty.medium) {
             printf("Performance Level: 🟡 Good (Medium)\n");

--- a/typingtutor.c
+++ b/typingtutor.c
@@ -211,6 +211,18 @@ void processAttempts(FILE *file)
         printf("Wrong Characters: %d\n", currentAttempt.wrongChars);
         printf("--------------------------------------------------------\n");
 
+        // Evaluate performance based on difficulty
+        if (currentAttempt.typingSpeed >= difficulty.hard) {
+            printf("Performance Level: 🟢 Excellent (Hard)\n");
+        } else if (currentAttempt.typingSpeed >= difficulty.medium) {
+            printf("Performance Level: 🟡 Good (Medium)\n");
+        } else if (currentAttempt.typingSpeed >= difficulty.easy) {
+            printf("Performance Level: 🟠 Basic (Easy)\n");
+        } else {
+            printf("Performance Level: 🔴 Below Easy - Keep practicing!\n");
+    }
+
+
         attempts[numAttempts++] = currentAttempt; // last 10 attempts are stored here
 
         if (numAttempts >= max_attempts)


### PR DESCRIPTION
This pull request addresses an issue where users could achieve inflated typing speed values by either:
Pressing Enter immediately without typing.
Pasting the paragraph text instead of typing it.
Such actions led to near-zero elapsed time, which distorted typing speed calculations.


CHANGES MADE:
Added a minimum elapsed time threshold (1 second). Attempts shorter than this are assumed to be pasted or invalid.
Validated that user input is not empty.
Skips invalid attempts and displays a warning without crashing the program.