### PR TITLE
Fix: Update .gitignore to include app/node_modules #ieeesoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 a.out
 *_profile.txt
+app/node_modules


### PR DESCRIPTION
Add `app/node_modules` to `.gitignore` to streamline our repository and prevent unnecessary files from being committed.

Files Changed:
`.gitignore`

